### PR TITLE
alphanumeric v2 encryted QR codes

### DIFF
--- a/src/krux/encryption.py
+++ b/src/krux/encryption.py
@@ -298,7 +298,11 @@ class EncryptedQRCode:
         if VERSIONS[version]["cksum"] == 0:
             bytes_to_encrypt += hashlib.sha256(bytes_to_encrypt).digest()[:16]
         bytes_encrypted = encryptor.encrypt(bytes_to_encrypt, version, i_vector)
-        return kef_encode(mnemonic_id, version, iterations, bytes_encrypted)
+        payload = kef_encode(mnemonic_id, version, iterations, bytes_encrypted)
+        if version < 2:
+            return payload
+        # Encode in base43 format
+        return base_encode(payload, 43).decode("ascii")
 
     def public_data(self, data):
         """Parse and returns encrypted mnemonic QR codes public data"""

--- a/src/krux/pages/login.py
+++ b/src/krux/pages/login.py
@@ -410,10 +410,18 @@ class Login(Page):
 
     def _encrypted_qr_code(self, data):
         from ..encryption import EncryptedQRCode
+        from ..baseconv import base_decode
 
         encrypted_qr = EncryptedQRCode()
         data_bytes = data.encode("latin-1") if isinstance(data, str) else data
-        public_data = encrypted_qr.public_data(data_bytes)
+        public_data = None
+        try:  # Try to decode base43 data
+            decoded_b43 = base_decode(data_bytes, 43)
+            public_data = encrypted_qr.public_data(decoded_b43)
+        except:
+            pass
+        if not public_data:  # Failed to decode and parse base43
+            public_data = encrypted_qr.public_data(data_bytes)
         if public_data:
             self.ctx.display.clear()
             if self.prompt(

--- a/tests/test_encryption.py
+++ b/tests/test_encryption.py
@@ -533,6 +533,7 @@ def test_decode_cbc_encrypted_qr_code(m5stickv):
 def test_check_encrypted_qr_code_lengths(m5stickv):
     from krux.encryption import EncryptedQRCode, VERSIONS
     from krux.krux_settings import Settings
+    from krux.baseconv import base_decode
 
     for version in VERSIONS:
         version_name = VERSIONS[version]["name"]
@@ -548,9 +549,11 @@ def test_check_encrypted_qr_code_lengths(m5stickv):
         elif version_name == "AES-CBC":
             assert len(qr_data) == 60
         elif version_name == "AES-ECB v2":
-            assert len(qr_data) == 44
+            assert len(qr_data) == 64  # base43 string
+            assert len(base_decode(qr_data.encode(), 43)) == 44
         elif version_name == "AES-CBC v2":
-            assert len(qr_data) == 60
+            assert len(qr_data) == 88  # base43 string
+            assert len(base_decode(qr_data.encode(), 43)) == 60
         else:
             print(f"Unknown version: {version_name}")
             assert 0


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Encode v2 encrypted QR codes as base43 strings, so QR codes can be generated in alphanumeric mode, thus keeping same densities and efficiency as respective binary v1 QRs
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other
