### PR TITLE
alphanumeric encryted QR  - move encoding to encryption_ui

### DIFF
--- a/src/krux/encryption.py
+++ b/src/krux/encryption.py
@@ -325,8 +325,7 @@ class EncryptedQRCode:
         if VERSIONS[version]["cksum"] == 0:
             bytes_to_encrypt += hashlib.sha256(bytes_to_encrypt).digest()[:16]
         bytes_encrypted = encryptor.encrypt(bytes_to_encrypt, version, i_vector)
-        payload = kef_encode(mnemonic_id, version, iterations, bytes_encrypted)
-        return payload
+        return kef_encode(mnemonic_id, version, iterations, bytes_encrypted)
 
     def public_data(self, data):
         """Parse and returns encrypted mnemonic QR codes public data"""

--- a/src/krux/pages/encryption_ui.py
+++ b/src/krux/pages/encryption_ui.py
@@ -156,6 +156,7 @@ class EncryptMnemonic(Page):
     def __init__(self, ctx):
         super().__init__(ctx, None)
         self.ctx = ctx
+        self.version_number = VERSION_NUMBERS[Settings().encryption.version]
 
     def encrypt_menu(self):
         """Menu with mnemonic encryption output options"""
@@ -187,7 +188,7 @@ class EncryptMnemonic(Page):
             self.flash_error(t("Key was not provided"))
             return None
 
-        version = VERSIONS[VERSION_NUMBERS[Settings().encryption.version]]
+        version = VERSIONS[self.version_number]
         i_vector = None
         if version["iv"]:
             self.ctx.display.clear()
@@ -275,6 +276,12 @@ class EncryptMnemonic(Page):
         del encrypted_qr
 
         from .qr_view import SeedQRView
+
+        if self.version_number > 1:
+            from ..baseconv import base_encode
+
+            # Convert to base43
+            qr_data = base_encode(qr_data, 43).decode("ascii")
 
         seed_qr_view = SeedQRView(self.ctx, data=qr_data, title=mnemonic_id)
         seed_qr_view.display_qr(allow_export=True)

--- a/tests/pages/test_encryption_ui.py
+++ b/tests/pages/test_encryption_ui.py
@@ -155,6 +155,7 @@ def test_encrypt_cbc_sd_ui(m5stickv, mocker, mock_file_operations):
     ctx = create_ctx(mocker, BTN_SEQUENCE)
     ctx.wallet = Wallet(Key(CBC_WORDS, TYPE_SINGLESIG, NETWORKS["main"]))
 
+    Settings().encryption.version = "AES-CBC"
     storage_ui = EncryptMnemonic(ctx)
     mocker.patch(
         "krux.pages.encryption_ui.EncryptionKey.encryption_key",
@@ -164,7 +165,6 @@ def test_encrypt_cbc_sd_ui(m5stickv, mocker, mock_file_operations):
         "krux.pages.capture_entropy.CameraEntropy.capture",
         mocker.MagicMock(return_value=I_VECTOR),
     )
-    Settings().encryption.version = "AES-CBC"
     storage_ui.encrypt_menu()
 
     ctx.display.draw_centered_text.assert_has_calls(
@@ -301,6 +301,7 @@ def test_encrypt_to_qrcode_cbc_ui(m5stickv, mocker):
     ctx = create_ctx(mocker, BTN_SEQUENCE)
     ctx.wallet = Wallet(Key(CBC_WORDS, TYPE_SINGLESIG, NETWORKS["main"]))
     ctx.printer = None
+    Settings().encryption.version = "AES-CBC"
     storage_ui = EncryptMnemonic(ctx)
     mocker.patch(
         "krux.pages.encryption_ui.EncryptionKey.encryption_key",
@@ -312,7 +313,6 @@ def test_encrypt_to_qrcode_cbc_ui(m5stickv, mocker):
     )
 
     with patch("krux.pages.qr_view.SeedQRView", mocker.MagicMock()) as qr_view:
-        Settings().encryption.version = "AES-CBC"
         storage_ui.encrypt_menu()
     qr_view.assert_has_calls(
         [


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
Adds base43 encoding for QR codes with version above 1 to encryption_ui
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other
