### PR TITLE
 Add kef test coverage from PR #647

### DIFF
--- a/src/krux/kef.py
+++ b/src/krux/kef.py
@@ -272,7 +272,10 @@ class Cipher:
     def _authenticate(self, decrypted, aes_object, auth, mode, v_auth, v_pkcs_pad):
         if not (
             isinstance(decrypted, bytes)
-            # TODO check aes_object
+            and (
+                mode != MODE_GCM
+                or (aes_object is not None and hasattr(aes_object, "verify"))
+            )
             and (isinstance(auth, bytes) or auth is None)
             and mode in MODE_NUMBERS.values()
             and (isinstance(v_auth, int) and -32 <= v_auth <= 32)

--- a/tests/test_kef.py
+++ b/tests/test_kef.py
@@ -342,10 +342,18 @@ def test_Cipher_calling_method__authenticate(m5stickv):
                                         v_pkcs_pad,
                                     )
 
-                            # # TODO solve this
-                            # for invalid in invalid_aes_objects:
-                            #    with pytest.raises(ValueError, match=err):
-                            #        aes._authenticate(plain, invalid, auth, mode, v_auth, v_pkcs_pad)
+                            # GCM requires a valid aes_object where .verify() can be called
+                            if mode == kef.MODE_GCM:
+                                for invalid in invalid_aes_objects:
+                                    with pytest.raises(ValueError, match=err):
+                                        cipher._authenticate(
+                                            plain,
+                                            invalid,
+                                            auth,
+                                            mode,
+                                            v_auth,
+                                            v_pkcs_pad,
+                                        )
 
                             for invalid in invalid_auths:
                                 with pytest.raises(ValueError, match=err):
@@ -442,6 +450,39 @@ def test_Cipher_public_sha256_auth_commits_to_key(m5stickv):
                 # To avoid this, KEF commits to the stretched key when auth bytes are public.
                 cksum = sha256(plain + cipher._key).digest()[:v_auth]
                 assert auth_bytes == cksum
+
+
+def test_Cipher_decrypt_exception_handling(m5stickv):
+    """Test that decrypt returns None when _authenticate raises an exception"""
+    from krux import kef
+
+    # Payload structure: iv + ciphertext + auth
+    iv = b"\x00" * 16
+    ciphertext = b"\x00" * 16
+    auth = b"\x00" * 4
+
+    cases_decrypt = [
+        (5, ciphertext + auth[:3]),  # ECB: no IV, 3-byte auth
+        (10, iv + ciphertext + auth),  # CBC: 16-byte IV, 4-byte auth
+        (15, iv[:12] + ciphertext + auth),  # CTR: 12-byte IV, 4-byte auth
+        (20, iv[:12] + ciphertext + auth),  # GCM: 12-byte IV, 4-byte auth
+    ]
+
+    for version, payload in cases_decrypt:
+        # Skip if version is disabled
+        if kef.VERSIONS.get(version) is None:
+            continue
+        if kef.VERSIONS[version].get("mode") is None:
+            continue
+
+        cipher = kef.Cipher(b"testkey", b"testsalt", 10000)
+
+        # Force _authenticate to fail by patching it
+        with patch.object(
+            cipher, "_authenticate", side_effect=Exception("Authentication failed")
+        ):
+            result = cipher.decrypt(payload, version)
+            assert result is None
 
 
 def test_faithful_encryption(m5stickv):
@@ -735,6 +776,27 @@ def test_suggest_versions(m5stickv):
 
         # end debugging
         assert version_name in [kef.VERSIONS[x]["name"] for x in suggesteds]
+
+
+def test_suggest_versions_with_disabled_versions(m5stickv):
+    """Test that suggest_versions skips disabled versions"""
+    from krux import kef
+
+    # Test cases for disabling versions
+    test_cases = [
+        (5, "set_none", "AES-ECB"),  # Disable entire version by setting to None
+        (10, "mode_none", "AES-CBC"),  # Disable by setting mode to None
+    ]
+
+    for version, disable_method, mode_name in test_cases:
+        # Disable the version
+        if disable_method == "set_none":
+            kef.VERSIONS[version] = None
+        else:
+            kef.VERSIONS[version]["mode"] = None
+
+        suggestions = kef.suggest_versions(b"test plaintext", mode_name)
+        assert version not in suggestions
 
 
 def test_wrapping_is_faithful(m5stickv):


### PR DESCRIPTION
  This adds the test coverage for kef.py edge cases from selfcustody/krux#647